### PR TITLE
Fix d128 support, except for Real and SuperOf traits.

### DIFF
--- a/alga/src/general/identity.rs
+++ b/alga/src/general/identity.rs
@@ -2,6 +2,8 @@ use std::cmp::{Ordering, PartialOrd};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign};
+#[cfg(feature = "decimal")]
+use decimal::d128;
 
 use num::{Num, One, Zero};
 
@@ -32,12 +34,12 @@ pub trait Identity<O: Operator> {
 
 impl_ident!(Additive; 0; u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
 impl_ident!(Additive; 0.; f32, f64);
-#[cfg(decimal)]
-impl_ident!(Additive; 0.; decimal::d128);
+#[cfg(feature = "decimal")]
+impl_ident!(Additive; d128!(0.); d128);
 impl_ident!(Multiplicative; 1; u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
 impl_ident!(Multiplicative; 1.; f32, f64);
-#[cfg(decimal)]
-impl_ident!(Multiplicative; 1.; decimal::d128);
+#[cfg(feature = "decimal")]
+impl_ident!(Multiplicative; d128!(1.); d128);
 
 impl<N: Identity<Additive>> Identity<Additive> for Complex<N> {
     #[inline]

--- a/alga/src/general/lattice.rs
+++ b/alga/src/general/lattice.rs
@@ -1,4 +1,6 @@
 use std::cmp::{Ordering, PartialOrd};
+#[cfg(feature = "decimal")]
+use decimal::d128;
 
 /// A set where every two elements have an infimum (i.e. greatest lower bound).
 pub trait MeetSemilattice: Sized {
@@ -118,5 +120,5 @@ macro_rules! impl_lattice(
 );
 
 impl_lattice!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
-#[cfg(decimal)]
-impl_lattice!(decimal::d128);
+#[cfg(feature = "decimal")]
+impl_lattice!(d128);

--- a/alga/src/general/one_operator.rs
+++ b/alga/src/general/one_operator.rs
@@ -1,6 +1,8 @@
 use num::Num;
 use num_complex::Complex;
 use std::ops::{Add, Mul};
+#[cfg(feature = "decimal")]
+use decimal::d128;
 
 use approx::RelativeEq;
 
@@ -372,11 +374,11 @@ macro_rules! impl_magma(
 );
 
 impl_magma!(Additive; add; u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
-#[cfg(decimal)]
-impl_ident!(Additive; add; decimal::d128);
+#[cfg(feature = "decimal")]
+impl_magma!(Additive; add; d128);
 impl_magma!(Multiplicative; mul; u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
-#[cfg(decimal)]
-impl_ident!(Multiplicative; mul; decimal::d128);
+#[cfg(feature = "decimal")]
+impl_magma!(Multiplicative; mul; d128);
 
 impl_monoid!(<Additive> for u8; u16; u32; u64; usize);
 impl_monoid!(<Multiplicative> for u8; u16; u32; u64; usize);

--- a/alga/src/general/operator.rs
+++ b/alga/src/general/operator.rs
@@ -1,5 +1,7 @@
 //! Operators traits and structures.
 pub use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
+#[cfg(feature = "decimal")]
+use decimal::d128;
 
 use num::Num;
 use num_complex::Complex;
@@ -74,8 +76,8 @@ macro_rules! impl_additive_inverse(
 );
 
 impl_additive_inverse!(i8, i16, i32, i64, isize, f32, f64);
-#[cfg(decimal)]
-impl_additive_inverse!(decimal::d128);
+#[cfg(feature = "decimal")]
+impl_additive_inverse!(d128);
 
 impl<N: Inverse<Additive>> Inverse<Additive> for Complex<N> {
     #[inline]
@@ -101,10 +103,10 @@ impl Inverse<Multiplicative> for f64 {
     }
 }
 
-#[cfg(decimal)]
-impl Inverse<Multiplicative> for decimal::d128 {
+#[cfg(feature = "decimal")]
+impl Inverse<Multiplicative> for d128 {
     #[inline]
-    fn inverse(&self) -> decimal::d128 {
+    fn inverse(&self) -> d128 {
         d128!(1.0) / self
     }
 }

--- a/alga/src/general/real.rs
+++ b/alga/src/general/real.rs
@@ -14,6 +14,8 @@ use libm::F32Ext;
 use libm::F64Ext;
 #[cfg(not(feature = "std"))]
 use num;
+//#[cfg(feature = "decimal")]
+//use decimal::d128;
 
 #[allow(missing_docs)]
 
@@ -418,5 +420,5 @@ macro_rules! impl_real(
 impl_real!(f32,f32,F32Ext; f64,f64,F64Ext);
 #[cfg(feature = "std")]
 impl_real!(f32,f32,f32; f64,f64,f64);
-#[cfg(decimal)]
-impl_real!(decimal::d128, decimal::d128);
+//#[cfg(feature = "decimal")]
+//impl_real!(d128, d128, d128);

--- a/alga/src/general/subset.rs
+++ b/alga/src/general/subset.rs
@@ -1,5 +1,7 @@
 use num::Zero;
 use num_complex::Complex;
+#[cfg(feature = "decimal")]
+use decimal::d128;
 
 /// Nested sets and conversions between them (using an injective mapping). Useful to work with
 /// substructures. In generic code, it is preferable to use `SupersetOf` as trait bound whenever
@@ -143,24 +145,24 @@ impl_subset!(
     f32 as f32, f64;
     f64 as f32, f64;
 );
-#[cfg(decimal)]
-impl_subset!(
-    u8 as decimal::d128;
-    u16 as decimal::d128;
-    u32 as decimal::d128;
-    u64 as decimal::d128;
-    usize as decimal::d128;
-
-    i8 as decimal::d128;
-    i16 as decimal::d128;
-    i32 as decimal::d128;
-    i64 as decimal::d128;
-    isize as decimal::d128;
-
-    f32 as decimal::d128;
-    f64 as decimal::d128;
-    decimal::d128 as decimal::d128;
-);
+//#[cfg(feature = "decimal")]
+//impl_subset!(
+//    u8 as d128;
+//    u16 as d128;
+//    u32 as d128;
+//    u64 as d128;
+//    usize as d128;
+//
+//    i8 as d128;
+//    i16 as d128;
+//    i32 as d128;
+//    i64 as d128;
+//    isize as d128;
+//
+//    f32 as d128;
+//    f64 as d128;
+//    d128 as d128;
+//);
 
 impl<N1, N2: SupersetOf<N1>> SubsetOf<Complex<N2>> for Complex<N1> {
     #[inline]
@@ -210,5 +212,5 @@ macro_rules! impl_scalar_subset_of_complex(
 );
 
 impl_scalar_subset_of_complex!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
-#[cfg(decimal)]
-impl_scalar_subset_of_complex!(decimal::d128);
+#[cfg(feature = "decimal")]
+impl_scalar_subset_of_complex!(d128);

--- a/alga/src/general/two_operators.rs
+++ b/alga/src/general/two_operators.rs
@@ -1,6 +1,8 @@
 use approx::RelativeEq;
 use num::Num;
 use num_complex::Complex;
+#[cfg(feature = "decimal")]
+use decimal::d128;
 
 use general::wrapper::Wrapper as W;
 use general::{
@@ -258,8 +260,8 @@ macro_rules! impl_field(
  */
 impl_ring_commutative!(<Additive, Multiplicative> for i8; i16; i32; i64; isize);
 impl_field!(<Additive, Multiplicative> for f32; f64);
-#[cfg(decimal)]
-impl_field!(<Additive, Multiplicative> for decimal::d128);
+#[cfg(feature = "decimal")]
+impl_field!(<Additive, Multiplicative> for d128);
 
 impl<N: Num + Clone + ClosedNeg + AbstractRing> AbstractRing for Complex<N> {}
 impl<N: Num + Clone + ClosedNeg + AbstractRingCommutative> AbstractRingCommutative for Complex<N> {}

--- a/alga/src/lib.rs
+++ b/alga/src/lib.rs
@@ -23,7 +23,7 @@
 
 #[macro_use]
 extern crate approx;
-#[cfg(decimal)]
+#[cfg(feature = "decimal")]
 extern crate decimal;
 #[cfg(not(feature = "std"))]
 extern crate libm;

--- a/alga/src/lib.rs
+++ b/alga/src/lib.rs
@@ -24,6 +24,7 @@
 #[macro_use]
 extern crate approx;
 #[cfg(feature = "decimal")]
+#[macro_use]
 extern crate decimal;
 #[cfg(not(feature = "std"))]
 extern crate libm;


### PR DESCRIPTION
The Real trait cannot be implemented because of missing implementation of traits from the `num` crate for `d128`.