### PR TITLE
Deprecate Inverse in favor of TwoSidedInverse

### DIFF
--- a/alga/src/general/mod.rs
+++ b/alga/src/general/mod.rs
@@ -156,8 +156,8 @@
 //! }
 //! ~~~
 
-pub use self::operator::{Additive, ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, Inverse,
-                         Multiplicative, Operator};
+pub use self::operator::{Additive, ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, TwoSidedInverse,
+                         Inverse, Multiplicative, Operator};
 pub use self::identity::{Id, Identity};
 pub use self::subset::{SubsetOf, SupersetOf};
 

--- a/alga/src/general/one_operator.rs
+++ b/alga/src/general/one_operator.rs
@@ -6,7 +6,7 @@ use decimal::d128;
 
 use approx::RelativeEq;
 
-use general::{Additive, ClosedNeg, Identity, Inverse, Multiplicative, Operator};
+use general::{Additive, ClosedNeg, Identity, TwoSidedInverse, Multiplicative, Operator};
 
 /// A magma is an algebraic structure which consists of a set equipped with a binary operation, ∘,
 /// which must be closed.
@@ -45,7 +45,7 @@ pub trait AbstractMagma<O: Operator>: Sized + Clone {
 /// ```
 /// 
 /// where "\" and "/" are respectively the **left** and **right** division. 
-pub trait AbstractQuasigroup<O: Operator>: PartialEq + AbstractMagma<O> + Inverse<O> {
+pub trait AbstractQuasigroup<O: Operator>: PartialEq + AbstractMagma<O> + TwoSidedInverse<O> {
     /// Returns `true` if latin squareness holds for the given arguments. Approximate
     /// equality is used for verifications.
     /// 
@@ -57,8 +57,8 @@ pub trait AbstractQuasigroup<O: Operator>: PartialEq + AbstractMagma<O> + Invers
         Self: RelativeEq,
     {
         let (a, b) = args;
-        relative_eq!(a, a.operate(&b.inverse()).operate(&b))
-            && relative_eq!(a, a.operate(&b.operate(&b.inverse())))
+        relative_eq!(a, a.operate(&b.two_sided_inverse()).operate(&b))
+            && relative_eq!(a, a.operate(&b.operate(&b.two_sided_inverse())))
 
         // TODO: pseudo inverse?
     }
@@ -73,7 +73,7 @@ pub trait AbstractQuasigroup<O: Operator>: PartialEq + AbstractMagma<O> + Invers
         Self: Eq,
     {
         let (a, b) = args;
-        a == a.operate(&b.inverse()).operate(&b) && a == a.operate(&b.operate(&b.inverse()))
+        a == a.operate(&b.two_sided_inverse()).operate(&b) && a == a.operate(&b.operate(&b.two_sided_inverse()))
 
         // TODO: pseudo inverse?
     }
@@ -85,7 +85,7 @@ pub trait AbstractQuasigroup<O: Operator>: PartialEq + AbstractMagma<O> + Invers
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractQuasigroup, Additive, Inverse};
+/// # use alga::general::{AbstractMagma, AbstractQuasigroup, Additive, TwoSidedInverse};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -96,9 +96,9 @@ pub trait AbstractQuasigroup<O: Operator>: PartialEq + AbstractMagma<O> + Invers
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///
@@ -191,7 +191,7 @@ pub trait AbstractLoop<O: Operator>: AbstractQuasigroup<O> + Identity<O> {}
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractLoop, Additive, Inverse, Identity};
+/// # use alga::general::{AbstractMagma, AbstractLoop, Additive, TwoSidedInverse, Identity};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -202,9 +202,9 @@ pub trait AbstractLoop<O: Operator>: AbstractQuasigroup<O> + Identity<O> {}
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///
@@ -299,7 +299,7 @@ pub trait AbstractGroup<O: Operator>: AbstractLoop<O> + AbstractMonoid<O> {}
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractGroup, Additive, Inverse, Identity};
+/// # use alga::general::{AbstractMagma, AbstractGroup, Additive, TwoSidedInverse, Identity};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -310,9 +310,9 @@ pub trait AbstractGroup<O: Operator>: AbstractLoop<O> + AbstractMonoid<O> {}
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///
@@ -369,7 +369,7 @@ pub trait AbstractGroupAbelian<O: Operator>: AbstractGroup<O> {
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractGroupAbelian, Additive, Inverse, Identity};
+/// # use alga::general::{AbstractMagma, AbstractGroupAbelian, Additive, TwoSidedInverse, Identity};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -380,9 +380,9 @@ pub trait AbstractGroupAbelian<O: Operator>: AbstractGroup<O> {
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///

--- a/alga/src/general/two_operators.rs
+++ b/alga/src/general/two_operators.rs
@@ -71,7 +71,7 @@ pub trait AbstractRing<A: Operator = Additive, M: Operator = Multiplicative>:
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractRing, Additive, Multiplicative, Inverse, Identity};
+/// # use alga::general::{AbstractMagma, AbstractRing, Additive, Multiplicative, TwoSidedInverse, Identity};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -82,9 +82,9 @@ pub trait AbstractRing<A: Operator = Additive, M: Operator = Multiplicative>:
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///
@@ -161,7 +161,7 @@ pub trait AbstractRingCommutative<A: Operator = Additive, M: Operator = Multipli
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractRingCommutative, Additive, Multiplicative, Inverse, Identity};
+/// # use alga::general::{AbstractMagma, AbstractRingCommutative, Additive, Multiplicative, TwoSidedInverse, Identity};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -172,9 +172,9 @@ pub trait AbstractRingCommutative<A: Operator = Additive, M: Operator = Multipli
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///
@@ -221,7 +221,7 @@ pub trait AbstractField<A: Operator = Additive, M: Operator = Multiplicative>:
 /// ```
 /// # #[macro_use]
 /// # extern crate alga;
-/// # use alga::general::{AbstractMagma, AbstractField, Additive, Multiplicative, Inverse, Identity};
+/// # use alga::general::{AbstractMagma, AbstractField, Additive, Multiplicative, TwoSidedInverse, Identity};
 /// # fn main() {}
 /// #[derive(PartialEq, Clone)]
 /// struct Wrapper<T>(T);
@@ -232,9 +232,9 @@ pub trait AbstractField<A: Operator = Additive, M: Operator = Multiplicative>:
 ///     }
 /// }
 ///
-/// impl<T: Inverse<Additive>> Inverse<Additive> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Additive>> TwoSidedInverse<Additive> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///
@@ -249,9 +249,9 @@ pub trait AbstractField<A: Operator = Additive, M: Operator = Multiplicative>:
 ///         Wrapper(self.0.operate(&right.0))
 ///     }
 /// }
-/// impl<T: Inverse<Multiplicative>> Inverse<Multiplicative> for Wrapper<T> {
-///     fn inverse(&self) -> Self {
-///         Wrapper(self.0.inverse())
+/// impl<T: TwoSidedInverse<Multiplicative>> TwoSidedInverse<Multiplicative> for Wrapper<T> {
+///     fn two_sided_inverse(&self) -> Self {
+///         Wrapper(self.0.two_sided_inverse())
 ///     }
 /// }
 ///

--- a/alga/src/general/wrapper.rs
+++ b/alga/src/general/wrapper.rs
@@ -9,7 +9,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 use general::AbstractMagma;
 use general::AbstractQuasigroup;
-use general::{Inverse, Operator};
+use general::{Inverse, TwoSidedInverse, Operator};
 
 /// Wrapper that allows to use operators on algebraic types.
 #[derive(Debug)]
@@ -118,7 +118,7 @@ where
 
     #[inline]
     fn neg(mut self) -> Self {
-        self.val = self.val.inverse();
+        self.val = self.val.two_sided_inverse();
         self
     }
 }
@@ -153,7 +153,7 @@ where
 {
     #[inline]
     fn inverse(&self) -> Self {
-        Wrapper::new(self.val.inverse())
+        Wrapper::new(self.val.two_sided_inverse())
     }
 }
 
@@ -165,6 +165,6 @@ where
 
     #[inline]
     fn div(self, lhs: Self) -> Self {
-        self * lhs.inverse()
+        self * lhs.two_sided_inverse()
     }
 }

--- a/alga/src/linear/matrix.rs
+++ b/alga/src/linear/matrix.rs
@@ -105,7 +105,7 @@ pub trait SquareMatrix:
     fn determinant(&self) -> Self::Field;
 
     // FIXME: add an epsilon value (as for try_normalize)?
-    /// Attempts to inverse `self`.
+    /// Attempts to two_sided_inverse `self`.
     #[inline]
     fn try_inverse(&self) -> Option<Self>;
 

--- a/alga/src/linear/transformation.rs
+++ b/alga/src/linear/transformation.rs
@@ -1,4 +1,4 @@
-use general::{ClosedDiv, ClosedMul, ClosedNeg, Id, Inverse, MultiplicativeGroup,
+use general::{ClosedDiv, ClosedMul, ClosedNeg, Id, TwoSidedInverse, MultiplicativeGroup,
               MultiplicativeMonoid, Real, SubsetOf};
 use linear::{EuclideanSpace, NormedSpace};
 
@@ -19,10 +19,10 @@ pub trait Transformation<E: EuclideanSpace>: MultiplicativeMonoid {
 /// The most general form of inversible transformations on an euclidean space.
 pub trait ProjectiveTransformation<E: EuclideanSpace>
     : MultiplicativeGroup + Transformation<E> {
-    /// Applies this group's inverse action on a point from the euclidean space.
+    /// Applies this group's two_sided_inverse action on a point from the euclidean space.
     fn inverse_transform_point(&self, pt: &E) -> E;
 
-    /// Applies this group's inverse action on a vector from the euclidean space.
+    /// Applies this group's two_sided_inverse action on a vector from the euclidean space.
     ///
     /// If `v` is a vector and `a, b` two point such that `v = a - b`, the action `∘` on a vector
     /// is defined as `self ∘ v = (self × a) - (self × b)`.
@@ -80,7 +80,7 @@ pub trait AffineTransformation<E: EuclideanSpace>: ProjectiveTransformation<E> {
     #[inline]
     fn append_rotation_wrt_point(&self, r: &Self::Rotation, p: &E) -> Option<Self> {
         if let Some(t) = Self::Translation::from_vector(p.coordinates()) {
-            let it = t.inverse();
+            let it = t.two_sided_inverse();
             Some(
                 self.append_translation(&it)
                     .append_rotation(&r)

--- a/alga_derive/src/lib.rs
+++ b/alga_derive/src/lib.rs
@@ -30,7 +30,7 @@
 //! marker traits required by the algebraic groupness property
 //! (`AbstractMonoid`, `AbstractSemigroup`, `AbstractLoop` and `AbstractQuasigroup`) for the target of the derive.
 //!
-//! Traits required by these marker traits (`Identity`, `PartialEq`, `Inverse` and `AbstractMagma`) should be implemented manually.
+//! Traits required by these marker traits (`Identity`, `PartialEq`, `TwoSidedInverse` and `AbstractMagma`) should be implemented manually.
 //!
 //! If `#[alga_quickcheck]` attribute is added for the target of the derive,
 //! then `quickcheck` tests will be generated.


### PR DESCRIPTION
Addresses #53 
For now, `Inverse` deprecated instead of removed to avoid a breaking change.