### PR TITLE
Implement VectorSpace for Complex.

### DIFF
--- a/alga/src/general/module.rs
+++ b/alga/src/general/module.rs
@@ -28,3 +28,14 @@ pub trait AbstractModule<
     /// Multiplies an element of the ring with an element of the module.
     fn multiply_by(&self, r: Self::AbstractRing) -> Self;
 }
+
+impl<N: AbstractRingCommutative<Additive, Multiplicative> + num::Num + crate::general::ClosedNeg>
+    AbstractModule<Additive, Additive, Multiplicative> for num_complex::Complex<N> {
+    type AbstractRing = N;
+
+    #[inline]
+    fn multiply_by(&self, r: N) -> Self {
+        self.clone() * r
+    }
+
+}

--- a/alga/src/general/real.rs
+++ b/alga/src/general/real.rs
@@ -1,7 +1,7 @@
-use num::{Bounded, FromPrimitive, Num, Signed};
+use num::{Bounded, FromPrimitive, Num, NumAssign, Signed};
 use std::any::Any;
 use std::fmt::{Debug, Display};
-use std::ops::{AddAssign, DivAssign, MulAssign, Neg, SubAssign};
+use std::ops::Neg;
 use std::{f32, f64};
 
 use approx::{RelativeEq, UlpsEq};
@@ -32,16 +32,12 @@ pub trait Real:
     + Field
     + Copy
     + Num
+    + NumAssign
     + FromPrimitive
     + Neg<Output = Self>
-    + AddAssign
-    + MulAssign
-    + SubAssign
-    + DivAssign
     + RelativeEq<Epsilon = Self>
     + UlpsEq<Epsilon = Self>
     + Lattice
-    + PartialEq
     + Signed
     + Send
     + Sync

--- a/alga/src/general/specialized.rs
+++ b/alga/src/general/specialized.rs
@@ -47,4 +47,8 @@ pub trait Module
     /// The underlying scalar field.
     type Ring: RingCommutative;
 }
+
 // FIXME: unfortunately, Module cannot be auto-impl-ed.
+impl<N: RingCommutative + num::NumAssign> Module for num_complex::Complex<N> {
+    type Ring = N;
+}


### PR DESCRIPTION
This is a breaking change because this required modifying the `Real` trait so it requires `RemAssign`. At the same time we removed some supertraits that were already required by `NumAssign` and `Num`.